### PR TITLE
case sensitivty

### DIFF
--- a/section
+++ b/section
@@ -37,7 +37,7 @@ $section_commit = nil
 $vagrant_version = nil
 
 require 'logger'
-require 'english'
+require 'English'
 
 # DEBUG < INFO < WARN < ERROR < FATAL < UNKNOWN/ANY
 


### PR DESCRIPTION
http://stackoverflow.com/questions/27294172/loaderror-cannot-load-such-file-english

To resolve this error on ubuntu 16.04 with ruby `ruby 2.3.0p0 (2015-12-25) [x86_64-linux-gnu]`
```
$ ./section 
/usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- english (LoadError)
	from /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from ./section:40:in `<main>'
```